### PR TITLE
fix adempiere base end-point on homologation.

### DIFF
--- a/docker-compose/nginx/api/envoy_proxy_homologation.conf
+++ b/docker-compose/nginx/api/envoy_proxy_homologation.conf
@@ -1,11 +1,11 @@
 # ADempiere Envoy service transcoding from gRPC to JSON
 #
-location /api/v1/pos/homologation/ {
+location /api/adempiere/v1/pos/homologation/ {
 	# Policy configuration here (authentication, rate limiting, logging...)
 
 	access_log /var/log/nginx/envoy_proxy_homologation.log main;
 
-	location /api/v1/pos/homologation/ {
+	location /api/adempiere/v1/pos/homologation/ {
 		add_header Access-Control-Allow-Methods *;
 
 		if ($request_method = OPTIONS) {


### PR DESCRIPTION

```bash
curl --location --request POST 'http://192.168.5.102:81/api/adempiere/v1/pos/homologation/1000002/process/-1/simulate?ts=1748493038360' \
--header 'Accept: application/json, text/plain, */*' \
--header 'Accept-Language: es-419,es;q=0.9' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDM2ODkxIiwiQURfQ2xpZW50X0lEIjoxMDAwMDAwLCJBRF9PcmdfSUQiOjEwMDAwMDksIkFEX1JvbGVfSUQiOjEwMDAwMDAsIkFEX1VzZXJfSUQiOjEwMDE0ODYsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMjAyLCJBRF9MYW5ndWFnZSI6ImVzX1ZFIiwiaWF0IjoxNzQ4NDkyMjYyLCJleHAiOjE3NDg1Nzg2NjJ9.sVtmSOQQLEL8FOW9MOjywtzL5iLRJomADi0ABb_rdZs' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Referer: http://localhost:9528/' \
--header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36' \
--data '{
    "id": -1,
    "posId": 1000002
}'
```